### PR TITLE
darwin: clean up errant lines in python.rb

### DIFF
--- a/scripts/darwin/python.rb
+++ b/scripts/darwin/python.rb
@@ -1,19 +1,3 @@
-Skip to content
- This repository
-Explore
-Gist
-Blog
-Help
-aaronaskew aaronaskew
- 
-3  Unwatch 
-  Star 1
- Fork 245alephobjects/Cura
-forked from daid/Cura
- branch: SteamEngine  Cura / scripts / darwin / python.rb
-aaronaskewaaronaskew 14 hours ago Updated homebrew python formula to newest official and changed MACOSX…
-2 contributors Ilya Kulakovaaronaskew
-383 lines (324 sloc)  15.644 kb RawBlameHistory   
 require "formula"
 
 class Python < Formula


### PR DESCRIPTION
It seems like some github UI text got saved into this file. This fixes that. The command below (in the README.md) now works.

```
brew install --build-bottle --fresh ./scripts/darwin/python.rb --universal
```